### PR TITLE
3.x

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -210,11 +210,7 @@ $rules = [
 
 $finder = Finder::create()
     ->in([
-        __DIR__ . '/app',
-        __DIR__ . '/config',
-        __DIR__ . '/database',
-        __DIR__ . '/resources',
-        __DIR__ . '/routes',
+        __DIR__ . '/src',
         __DIR__ . '/tests',
     ])
     ->name('*.php')

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,18 +1,220 @@
 <?php
 
+declare(strict_types=1);
+
+use AdamWojs\PhpCsFixerPhpdocForceFQCN\Fixer\Phpdoc\ForceFQCNFixer;
 use PhpCsFixer\Config;
 use PhpCsFixer\Finder;
 
-/** @var Config $config */
-$config = require_once join(DIRECTORY_SEPARATOR, [__DIR__, 'vendor', 'netsells', 'code-standards-laravel', 'phpcsfixer', 'config.php']);
-
-$rules = array_merge_recursive($config->getRules(), [
-    // set project specific rules here
-]);
+$rules = [
+    'array_indentation' => true,
+    'array_syntax' => ['syntax' => 'short'],
+    'binary_operator_spaces' => [
+        'default' => 'single_space',
+    ],
+    'blank_line_after_namespace' => true,
+    'blank_line_after_opening_tag' => true,
+    'blank_line_before_statement' => [
+        'statements' => [
+            'continue',
+            'return',
+        ],
+    ],
+    'control_structure_braces' => true,
+    'control_structure_continuation_position' => [
+        'position' => 'same_line',
+    ],
+    'curly_braces_position' => [
+        'control_structures_opening_brace' => 'same_line',
+        'functions_opening_brace' => 'next_line_unless_newline_at_signature_end',
+        'anonymous_functions_opening_brace' => 'same_line',
+        'classes_opening_brace' => 'next_line_unless_newline_at_signature_end',
+        'anonymous_classes_opening_brace' => 'next_line_unless_newline_at_signature_end',
+        'allow_single_line_empty_anonymous_classes' => false,
+        'allow_single_line_anonymous_functions' => false,
+    ],
+    'cast_spaces' => true,
+    'class_attributes_separation' => [
+        'elements' => [
+            'const' => 'one',
+            'method' => 'one',
+            'property' => 'one',
+            'trait_import' => 'none',
+        ],
+    ],
+    'class_definition' => [
+        'multi_line_extends_each_single_line' => true,
+        'single_item_single_line' => true,
+        'single_line' => true,
+    ],
+    'clean_namespace' => true,
+    'compact_nullable_typehint' => true,
+    'concat_space' => [
+        'spacing' => 'none',
+    ],
+    'constant_case' => ['case' => 'lower'],
+    'declare_equal_normalize' => true,
+    'declare_parentheses' => true,
+    'elseif' => true,
+    'encoding' => true,
+    'full_opening_tag' => true,
+    'fully_qualified_strict_types' => [
+        'import_symbols' => false,
+        'leading_backslash_in_global_namespace' => true,
+        'phpdoc_tags' => [],
+    ],
+    'function_declaration' => true,
+    'function_typehint_space' => true,
+    'general_phpdoc_tag_rename' => true,
+    'heredoc_to_nowdoc' => true,
+    'include' => true,
+    'increment_style' => ['style' => 'post'],
+    'indentation_type' => true,
+    'integer_literal_case' => true,
+    'lambda_not_used_import' => true,
+    'linebreak_after_opening_tag' => true,
+    'line_ending' => true,
+    'list_syntax' => true,
+    'lowercase_cast' => true,
+    'lowercase_keywords' => true,
+    'lowercase_static_reference' => true,
+    'magic_method_casing' => true,
+    'magic_constant_casing' => true,
+    'method_argument_space' => [
+        'on_multiline' => 'ignore',
+    ],
+    'multiline_whitespace_before_semicolons' => [
+        'strategy' => 'no_multi_line',
+    ],
+    'native_function_casing' => true,
+    'native_function_type_declaration_casing' => true,
+    'no_alias_functions' => true,
+    'no_alias_language_construct_call' => true,
+    'no_alternative_syntax' => true,
+    'no_binary_string' => true,
+    'no_blank_lines_after_class_opening' => true,
+    'no_blank_lines_after_phpdoc' => true,
+    'no_closing_tag' => true,
+    'no_empty_phpdoc' => true,
+    'no_empty_statement' => true,
+    'no_extra_blank_lines' => [
+        'tokens' => [
+            'extra',
+            'throw',
+            'use',
+        ],
+    ],
+    'no_leading_import_slash' => true,
+    'no_leading_namespace_whitespace' => true,
+    'no_mixed_echo_print' => [
+        'use' => 'echo',
+    ],
+    'no_multiline_whitespace_around_double_arrow' => true,
+    'no_multiple_statements_per_line' => true,
+    'no_short_bool_cast' => true,
+    'no_singleline_whitespace_before_semicolons' => true,
+    'no_spaces_after_function_name' => true,
+    'no_space_around_double_colon' => true,
+    'no_spaces_around_offset' => [
+        'positions' => ['inside', 'outside'],
+    ],
+    'no_spaces_inside_parenthesis' => true,
+    'no_superfluous_phpdoc_tags' => [
+        'allow_mixed' => true,
+        'allow_unused_params' => true,
+    ],
+    'no_trailing_comma_in_singleline' => true,
+    'no_trailing_whitespace' => true,
+    'no_trailing_whitespace_in_comment' => true,
+    'no_unneeded_control_parentheses' => [
+        'statements' => ['break', 'clone', 'continue', 'echo_print', 'return', 'switch_case', 'yield'],
+    ],
+    'no_unneeded_curly_braces' => true,
+    'no_unset_cast' => true,
+    'no_unused_imports' => true,
+    'no_unreachable_default_argument_value' => true,
+    'no_useless_return' => true,
+    'no_whitespace_before_comma_in_array' => true,
+    'no_whitespace_in_blank_line' => true,
+    'normalize_index_brace' => true,
+    'not_operator_with_successor_space' => true,
+    'object_operator_without_whitespace' => true,
+    'ordered_imports' => ['sort_algorithm' => 'alpha'],
+    'psr_autoloading' => false,
+    'phpdoc_indent' => true,
+    'phpdoc_inline_tag_normalizer' => true,
+    'phpdoc_no_access' => true,
+    'phpdoc_no_package' => true,
+    'phpdoc_no_useless_inheritdoc' => true,
+    'phpdoc_order' => [
+        'order' => ['param', 'return', 'throws'],
+    ],
+    'phpdoc_scalar' => true,
+    'phpdoc_separation' => [
+        'groups' => [
+            ['deprecated', 'link', 'see', 'since'],
+            ['author', 'copyright', 'license'],
+            ['category', 'package', 'subpackage'],
+            ['property', 'property-read', 'property-write'],
+            ['param', 'return'],
+        ],
+    ],
+    'phpdoc_single_line_var_spacing' => true,
+    'phpdoc_summary' => false,
+    'phpdoc_to_comment' => false,
+    'phpdoc_tag_type' => [
+        'tags' => [
+            'inheritdoc' => 'inline',
+        ],
+    ],
+    'phpdoc_trim' => true,
+    'phpdoc_types' => true,
+    'phpdoc_var_without_name' => true,
+    'php_unit_method_casing' => [
+        'case' => 'snake_case'
+    ],
+    'return_type_declaration' => ['space_before' => 'none'],
+    'self_accessor' => false,
+    'self_static_accessor' => true,
+    'short_scalar_cast' => true,
+    'simplified_null_return' => false,
+    'single_blank_line_at_eof' => true,
+    'single_blank_line_before_namespace' => true,
+    'single_class_element_per_statement' => [
+        'elements' => ['const', 'property'],
+    ],
+    'single_import_per_statement' => true,
+    'single_line_after_imports' => true,
+    'single_line_comment_style' => [
+        'comment_types' => ['hash'],
+    ],
+    'single_quote' => true,
+    'single_space_around_construct' => true,
+    'space_after_semicolon' => true,
+    'standardize_not_equals' => true,
+    'statement_indentation' => false,
+    'switch_case_semicolon_to_colon' => true,
+    'switch_case_space' => true,
+    'ternary_operator_spaces' => true,
+    'trailing_comma_in_multiline' => ['elements' => ['arrays']],
+    'trim_array_spaces' => true,
+    'types_spaces' => true,
+    'unary_operator_spaces' => true,
+    'visibility_required' => [
+        'elements' => ['method', 'property'],
+    ],
+    'whitespace_after_comma_in_array' => true,
+    '@PHP82Migration' => true,
+    'AdamWojs/phpdoc_force_fqcn_fixer' => true,
+];
 
 $finder = Finder::create()
     ->in([
-        __DIR__ . '/src',
+        __DIR__ . '/app',
+        __DIR__ . '/config',
+        __DIR__ . '/database',
+        __DIR__ . '/resources',
+        __DIR__ . '/routes',
         __DIR__ . '/tests',
     ])
     ->name('*.php')
@@ -20,6 +222,15 @@ $finder = Finder::create()
     ->ignoreDotFiles(true)
     ->ignoreVCS(true);
 
+$config = new Config();
+
+$config->registerCustomFixers([
+    new ForceFQCNFixer()
+]);
+
 return $config
     ->setFinder($finder)
-    ->setRules($rules);
+    ->setRules($rules)
+    ->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect())
+    ->setRiskyAllowed(true)
+    ->setUsingCache(true);

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,9 @@
   "require-dev": {
     "orchestra/testbench": "^10.0",
     "tmarsteel/mockery-callable-mock": "~2.1",
-    "larastan/larastan": "^3.0"
+    "larastan/larastan": "^3.0",
+    "friendsofphp/php-cs-fixer": "^3.86",
+    "adamwojs/php-cs-fixer-phpdoc-force-fqcn": "^2.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,44 +1,44 @@
 {
-    "name": "netsells/laravel-resourceful",
-    "description": "Laravel API Resources supercharged to get rid of N+1 problems.",
-    "type": "library",
-    "license": "MIT",
-    "keywords": [
-        "laravel",
-        "netsells",
-        "api resource",
-        "eager loading"
-    ],
-    "authors": [
-        {
-            "name": "Jakub Gawron",
-            "email": "jakub.gawron@netsells.co.uk"
-        },
-        {
-            "name": "Sam Jordan",
-            "email": "sam.jordan@netsells.co.uk"
-        }
-    ],
-    "require": {
-        "php": "^8.2",
-        "ext-json": "*",
-        "laravel/framework": "^11.0"
+  "name": "netsells/laravel-resourceful",
+  "description": "Laravel API Resources supercharged to get rid of N+1 problems.",
+  "type": "library",
+  "license": "MIT",
+  "keywords": [
+    "laravel",
+    "netsells",
+    "api resource",
+    "eager loading"
+  ],
+  "authors": [
+    {
+      "name": "Jakub Gawron",
+      "email": "jakub.gawron@netsells.co.uk"
     },
-    "require-dev": {
-        "orchestra/testbench": "^9.0",
-        "tmarsteel/mockery-callable-mock": "~2.1",
-        "netsells/code-standards-laravel": "^1.1"
-    },
-    "autoload": {
-        "psr-4": {
-            "Netsells\\Http\\Resources\\": "src/",
-            "Netsells\\Http\\Resources\\Tests\\": "tests/"
-        }
-    },
-    "scripts": {
-        "phpstan": "vendor/bin/phpstan",
-        "lint": "vendor/bin/php-cs-fixer fix --dry-run --diff",
-        "format": "vendor/bin/php-cs-fixer fix",
-        "test": "vendor/bin/phpunit"
+    {
+      "name": "Sam Jordan",
+      "email": "sam.jordan@netsells.co.uk"
     }
+  ],
+  "require": {
+    "php": "^8.2",
+    "ext-json": "*",
+    "laravel/framework": "^12.0"
+  },
+  "require-dev": {
+    "orchestra/testbench": "^10.0",
+    "tmarsteel/mockery-callable-mock": "~2.1",
+    "larastan/larastan": "^3.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "Netsells\\Http\\Resources\\": "src/",
+      "Netsells\\Http\\Resources\\Tests\\": "tests/"
+    }
+  },
+  "scripts": {
+    "phpstan": "vendor/bin/phpstan",
+    "lint": "vendor/bin/php-cs-fixer fix --dry-run --diff",
+    "format": "vendor/bin/php-cs-fixer fix",
+    "test": "vendor/bin/phpunit"
+  }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 includes:
-    - ../../../larastan/larastan/extension.neon
+    - vendor/larastan/larastan/extension.neon
 
 parameters:
     paths:
@@ -11,5 +11,3 @@ parameters:
 
     ignoreErrors:
     excludePaths:
-
-    checkMissingIterableValueType: false

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 includes:
-    - ./vendor/netsells/code-standards-laravel/phpstan/extension.neon
+    - ../../../larastan/larastan/extension.neon
 
 parameters:
     paths:

--- a/src/ResolvesResources.php
+++ b/src/ResolvesResources.php
@@ -2,7 +2,6 @@
 
 namespace Netsells\Http\Resources;
 
-use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\PotentiallyMissing;
 use Illuminate\Support\Arr;
@@ -17,8 +16,8 @@ trait ResolvesResources
     /**
      * Create an HTTP response that represents the object.
      *
-     * @param Request $request
-     * @return JsonResponse
+     * @param \Illuminate\Http\Request $request
+     * @return \Illuminate\Http\JsonResponse
      */
     public function toResponse($request)
     {
@@ -30,7 +29,7 @@ trait ResolvesResources
     /**
      * Resolve the resource to an array.
      *
-     * @param Request|null $request
+     * @param \Illuminate\Http\Request|null $request
      * @return array
      */
     public function resolve($request = null)

--- a/src/ResolvesResources.php
+++ b/src/ResolvesResources.php
@@ -35,6 +35,7 @@ trait ResolvesResources
     public function resolve($request = null)
     {
         if ($this->resolvingRoot) {
+            /** @phpstan-ignore-next-line */
             if (method_exists($this, 'beforeResolveRoot')) {
                 $this->beforeResolveRoot($request);
             }

--- a/tests/Integration/BooksIndexResourceTest.php
+++ b/tests/Integration/BooksIndexResourceTest.php
@@ -66,6 +66,7 @@ class BooksIndexResourceTest extends ResourceTestCase
                 ->where('id', '!=', $book->author_id)
                 ->get();
 
+                
             $book->coauthors()->saveMany($otherAuthors);
         });
     }

--- a/tests/Integration/BooksIndexResourceTest.php
+++ b/tests/Integration/BooksIndexResourceTest.php
@@ -28,7 +28,7 @@ class BooksIndexResourceTest extends ResourceTestCase
      */
     protected function produce(int $amount)
     {
-        /** @var Book|Collection<Book> $books */
+        /** @var \Netsells\Http\Resources\Tests\Integration\Database\Models\Book|Collection<Book> $books */
         $books = Book::factory()->count($amount > 1 ? $amount : null)->forAuthor()->create();
 
         $this->assignAuthors();

--- a/tests/Integration/Database/Models/Author.php
+++ b/tests/Integration/Database/Models/Author.php
@@ -2,7 +2,6 @@
 
 namespace Netsells\Http\Resources\Tests\Integration\Database\Models;
 
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -13,8 +12,8 @@ use Netsells\Http\Resources\Tests\Integration\Database\Factories\AuthorFactory;
  * @property int $id
  * @property string $firstname
  * @property string $lastname
- * @property Collection|Book[] $books
- * @property Collection|Author[] $collaborators
+ * @property \Illuminate\Database\Eloquent\Collection|Book[] $books
+ * @property \Illuminate\Database\Eloquent\Collection|Author[] $collaborators
  */
 class Author extends Model
 {

--- a/tests/Integration/Database/Models/Book.php
+++ b/tests/Integration/Database/Models/Book.php
@@ -2,7 +2,6 @@
 
 namespace Netsells\Http\Resources\Tests\Integration\Database\Models;
 
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -18,9 +17,9 @@ use Netsells\Http\Resources\Tests\Integration\Database\Factories\BookFactory;
  * @property string $text
  * @property Shelf $shelf
  * @property Author $author
- * @property Collection|Author[] $coauthors
- * @property Collection|Genre[] $genres
- * @property Collection|Book[] $relatedBooks
+ * @property \Illuminate\Database\Eloquent\Collection|Author[] $coauthors
+ * @property \Illuminate\Database\Eloquent\Collection|Genre[] $genres
+ * @property \Illuminate\Database\Eloquent\Collection|Book[] $relatedBooks
  */
 class Book extends Model
 {

--- a/tests/Integration/Database/Models/Book.php
+++ b/tests/Integration/Database/Models/Book.php
@@ -27,26 +27,31 @@ class Book extends Model
 
     public $timestamps = false;
 
+    /** @return BelongsTo<Shelf, $this> */
     public function shelf(): BelongsTo
     {
         return $this->belongsTo(Shelf::class);
     }
 
+    /** @return BelongsTo<Author, $this> */
     public function author(): BelongsTo
     {
         return $this->belongsTo(Author::class);
     }
 
+    /** @return BelongsToMany<Author, $this> */
     public function coauthors(): BelongsToMany
     {
         return $this->belongsToMany(Author::class, 'book_coauthor', 'book_id', 'author_id');
     }
 
+    /** @return BelongsToMany<Genre, $this> */
     public function genres(): BelongsToMany
     {
         return $this->belongsToMany(Genre::class);
     }
 
+    /** @return BelongsToMany<Book, $this> */
     public function relatedBooks(): BelongsToMany
     {
         return $this->belongsToMany(Book::class, 'related_books', 'book_id', 'related_book_id');

--- a/tests/Integration/Database/Models/Genre.php
+++ b/tests/Integration/Database/Models/Genre.php
@@ -2,7 +2,6 @@
 
 namespace Netsells\Http\Resources\Tests\Integration\Database\Models;
 
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
@@ -10,7 +9,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
  * @property int $id
  * @property bool $fiction
  * @property string $name
- * @property Collection|Book[] $books
+ * @property \Illuminate\Database\Eloquent\Collection|Book[] $books
  */
 class Genre extends Model
 {

--- a/tests/Integration/Database/Models/Library.php
+++ b/tests/Integration/Database/Models/Library.php
@@ -2,7 +2,6 @@
 
 namespace Netsells\Http\Resources\Tests\Integration\Database\Models;
 
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -13,8 +12,8 @@ use Netsells\Http\Resources\Tests\Integration\Database\Factories\LibraryFactory;
  * @property int $id
  * @property string $name
  * @property string $city
- * @property Collection|Shelf[] $shelves
- * @property Collection|Book[] $books
+ * @property \Illuminate\Database\Eloquent\Collection|Shelf[] $shelves
+ * @property \Illuminate\Database\Eloquent\Collection|Book[] $books
  */
 class Library extends Model
 {

--- a/tests/Integration/Database/Models/Shelf.php
+++ b/tests/Integration/Database/Models/Shelf.php
@@ -2,7 +2,6 @@
 
 namespace Netsells\Http\Resources\Tests\Integration\Database\Models;
 
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -16,8 +15,8 @@ use Netsells\Http\Resources\Tests\Integration\Database\Factories\ShelfFactory;
  * @property string $row
  * @property string $column
  * @property Library $library
- * @property Collection|Book[] $books
- * @property Collection|Author[] $authors
+ * @property \Illuminate\Database\Eloquent\Collection|Book[] $books
+ * @property \Illuminate\Database\Eloquent\Collection|Author[] $authors
  */
 class Shelf extends Model
 {

--- a/tests/Integration/OptimalNumberOfQueriesTest.php
+++ b/tests/Integration/OptimalNumberOfQueriesTest.php
@@ -5,6 +5,7 @@ namespace Netsells\Http\Resources\Tests\Integration;
 use Netsells\Http\Resources\Tests\Integration\Database\Models\Library;
 use Netsells\Http\Resources\Tests\Integration\Resources\Basic;
 use Netsells\Http\Resources\Tests\Integration\Resources\Super;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class OptimalNumberOfQueriesTest extends TestCase
 {
@@ -20,9 +21,7 @@ class OptimalNumberOfQueriesTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider resourceProvider
-     */
+    #[DataProvider('resourceProvider')]
     public function test_creates_as_many_queries_as_eager_loading_resource_collection(string $basicClass, string $superClass)
     {
         $this->fullLibraryFactory()->create();
@@ -52,9 +51,7 @@ class OptimalNumberOfQueriesTest extends TestCase
         $this->assertEquals(count($optimalQueryLog), count($normalQueryLog));
     }
 
-    /**
-     * @dataProvider resourceProvider
-     */
+    #[DataProvider('resourceProvider')]
     public function test_creates_as_many_queries_as_lazy_eager_loading_resource_collection(string $basicClass, string $superClass)
     {
         $this->fullLibraryFactory()->create();
@@ -78,9 +75,7 @@ class OptimalNumberOfQueriesTest extends TestCase
         $this->assertEquals(count($optimalQueryLog), count($normalQueryLog));
     }
 
-    /**
-     * @dataProvider resourceProvider
-     */
+    #[DataProvider('resourceProvider')]
     public function test_creates_as_many_queries_as_eager_loading_resource(string $basicClass, string $superClass)
     {
         $this->fullLibraryFactory()->create();
@@ -110,9 +105,7 @@ class OptimalNumberOfQueriesTest extends TestCase
         $this->assertEquals(count($optimalQueryLog), count($normalQueryLog));
     }
 
-    /**
-     * @dataProvider resourceProvider
-     */
+    #[DataProvider('resourceProvider')]
     public function test_creates_as_many_queries_as_lazy_eager_loading_resource(string $basicClass, string $superClass)
     {
         $this->fullLibraryFactory()->create();

--- a/tests/Integration/PreloadModeTest.php
+++ b/tests/Integration/PreloadModeTest.php
@@ -10,7 +10,7 @@ class PreloadModeTest extends TestCase
 {
     public function test_preload_loads_single_relation_on_resource()
     {
-        /** @var Book $book */
+        /** @var \Netsells\Http\Resources\Tests\Integration\Database\Models\Book $book */
         $book = Book::factory()->forAuthor()->create()->fresh();
 
         BookWithSingleRelation::make($book)->response();
@@ -20,7 +20,7 @@ class PreloadModeTest extends TestCase
 
     public function test_preload_loads_multiple_relations_on_resource()
     {
-        /** @var Book $book */
+        /** @var \Netsells\Http\Resources\Tests\Integration\Database\Models\Book $book */
         $book = Book::factory()->forAuthor()->create()->fresh();
 
         BookWithMultiRelations::make($book)->response();
@@ -31,7 +31,7 @@ class PreloadModeTest extends TestCase
 
     public function test_preload_loads_single_relation_on_resource_collection()
     {
-        /** @var Book[] $books */
+        /** @var \Netsells\Http\Resources\Tests\Integration\Database\Models\Book[] $books */
         $books = Book::factory()->count(3)->forAuthor()->create()->fresh();
 
         BookWithSingleRelation::collection($books)->response();
@@ -43,7 +43,7 @@ class PreloadModeTest extends TestCase
 
     public function test_preload_loads_multiple_relations_on_resource_collection()
     {
-        /** @var Book[] $books */
+        /** @var \Netsells\Http\Resources\Tests\Integration\Database\Models\Book[] $books */
         $books = Book::factory()->count(3)->forAuthor()->create()->fresh();
 
         BookWithMultiRelations::collection($books)->response();

--- a/tests/Integration/Presets.php
+++ b/tests/Integration/Presets.php
@@ -2,7 +2,6 @@
 
 namespace Netsells\Http\Resources\Tests\Integration;
 
-use Faker\Generator as Faker;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Netsells\Http\Resources\Tests\Integration\Database\Models\Author;
 use Netsells\Http\Resources\Tests\Integration\Database\Models\Book;
@@ -10,7 +9,7 @@ use Netsells\Http\Resources\Tests\Integration\Database\Models\Library;
 use Netsells\Http\Resources\Tests\Integration\Database\Models\Shelf;
 
 /**
- * @property Faker $faker
+ * @property \Faker\Generator $faker
  */
 trait Presets
 {

--- a/tests/Integration/ResourceTestCase.php
+++ b/tests/Integration/ResourceTestCase.php
@@ -4,6 +4,7 @@ namespace Netsells\Http\Resources\Tests\Integration;
 
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 abstract class ResourceTestCase extends TestCase
 {
@@ -13,9 +14,7 @@ abstract class ResourceTestCase extends TestCase
 
     protected int $collectionSize = 4;
 
-    /**
-     * @dataProvider resourceProvider
-     */
+    #[DataProvider('resourceProvider')]
     public function test_super_reduces_queries_over_basic_resource_and_both_match(string $basicClass, string $superClass)
     {
         /** @var Model $model */
@@ -32,9 +31,7 @@ abstract class ResourceTestCase extends TestCase
         $this->assert($basicResource, $basicQueryLog, $superResource, $superQueryLog);
     }
 
-    /**
-     * @dataProvider resourceProvider
-     */
+    #[DataProvider('resourceProvider')]
     public function test_super_reduces_queries_over_basic_resource_collection_and_both_match(string $basicClass, string $superClass)
     {
         /** @var Collection $models */

--- a/tests/Integration/ResourceTestCase.php
+++ b/tests/Integration/ResourceTestCase.php
@@ -2,8 +2,6 @@
 
 namespace Netsells\Http\Resources\Tests\Integration;
 
-use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Database\Eloquent\Model;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 abstract class ResourceTestCase extends TestCase
@@ -17,7 +15,7 @@ abstract class ResourceTestCase extends TestCase
     #[DataProvider('resourceProvider')]
     public function test_super_reduces_queries_over_basic_resource_and_both_match(string $basicClass, string $superClass)
     {
-        /** @var Model $model */
+        /** @var \Illuminate\Database\Eloquent\Model $model */
         $model = $this->produce(1)->fresh();
         $basicResource = $this->withQueryLog($basicQueryLog, function () use ($basicClass, $model) {
             return $basicClass::make($model)->response()->content();
@@ -34,7 +32,7 @@ abstract class ResourceTestCase extends TestCase
     #[DataProvider('resourceProvider')]
     public function test_super_reduces_queries_over_basic_resource_collection_and_both_match(string $basicClass, string $superClass)
     {
-        /** @var Collection $models */
+        /** @var \Illuminate\Database\Eloquent\Collection $models */
         $models = $this->produce($this->collectionSize)->fresh();
         $basicResource = $this->withQueryLog($basicQueryLog, function () use ($basicClass, $models) {
             return $basicClass::collection($models)->response()->content();
@@ -77,7 +75,7 @@ abstract class ResourceTestCase extends TestCase
     }
 
     /**
-     * @return Collection|Model
+     * @return \Illuminate\Database\Eloquent\Collection|\Illuminate\Database\Eloquent\Model
      */
     abstract protected function produce(int $amount);
 }

--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -24,7 +24,7 @@ abstract class TestCase extends BaseTestCase
 
     protected function withQueryLog(mixed &$queryLog, callable $fn): mixed
     {
-        /** @var Connection $connection */
+        /** @var \Illuminate\Database\Connection $connection */
         $connection = $this->app->get(Connection::class);
         $connection->enableQueryLog();
         $connection->flushQueryLog();

--- a/tests/Integration/UseModeTest.php
+++ b/tests/Integration/UseModeTest.php
@@ -13,7 +13,7 @@ class UseModeTest extends TestCase
 {
     public function test_use_loads_and_provides_single_relation()
     {
-        /** @var Book $book */
+        /** @var \Netsells\Http\Resources\Tests\Integration\Database\Models\Book $book */
         $book = Book::factory()->forAuthor()->create()->fresh();
 
         BookWithSingleRelation::make($book)
@@ -27,7 +27,7 @@ class UseModeTest extends TestCase
 
     public function test_use_loads_and_provides_multiple_relations()
     {
-        /** @var Book $book */
+        /** @var \Netsells\Http\Resources\Tests\Integration\Database\Models\Book $book */
         $book = Book::factory()->forAuthor()->create()->fresh();
 
         BookWithMultiRelations::make($book)
@@ -42,7 +42,7 @@ class UseModeTest extends TestCase
 
     public function test_use_skips_missing_value()
     {
-        /** @var Book $book */
+        /** @var \Netsells\Http\Resources\Tests\Integration\Database\Models\Book $book */
         $book = Book::factory()->forAuthor()->create()->fresh();
 
         $response = BookWithMissingRelation::make($book)


### PR DESCRIPTION
## Overview
- [X] I have performed a self review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added sufficient logging
- [X] New and existing tests pass locally with my changes
- [ ] The code modified as part of this PR has been covered with tests

### Problem statement
This project was not compatible with Laravel 12. 

### Solution
This update makes this project compatible with Laravel 12.

In addition, the code-standards repository was adding a config for php-cs-fixer and phpstan. These have now been added inline. The dependency on that project has been removed, thus removing the requirement on Netsells.

### Dependencies
None

### Test procedures
Tests in the project pass, linting etc still works.

### Links

No specific link for this task - being done as part of the Laravel 12 upgrade of Parkmaven.

This repository could potentially be merged into the Parkmaven repository at some point, given it is the only known consumer of this repository.

## Deployment

### Migrations
No

### Environment variables
No

### Deployment notes
None
