### PR TITLE
Adds support for Laravel 13.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,8 +9,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.2', '8.3' ]
-        laravel: [ '^11.0' ]
+        php: ["8.2", "8.3", "8.4", "8.5"]
+        laravel: ["^12.0", "^13.0"]
+        exclude:
+          - php: "8.2"
+            laravel: "^13.0"
 
     steps:
       - name: Checkout the repo

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: laravel-resourceful
+  annotations:
+    github.com/project-slug: yourparkingspace/laravel-resourceful
+spec:
+  type: service
+  lifecycle: production
+  owner: marketplace-backend

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   type: service
   lifecycle: production
-  owner: marketplace-backend
+  owner: parkmaven

--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,10 @@
   "require": {
     "php": "^8.2",
     "ext-json": "*",
-    "laravel/framework": "^12.0"
+    "laravel/framework": "^12.0|^13.0"
   },
   "require-dev": {
-    "orchestra/testbench": "^10.0",
+    "orchestra/testbench": "^10.0|^11.0",
     "tmarsteel/mockery-callable-mock": "~2.1",
     "larastan/larastan": "^3.0",
     "friendsofphp/php-cs-fixer": "^3.86",

--- a/src/ResolvesResources.php
+++ b/src/ResolvesResources.php
@@ -35,15 +35,16 @@ trait ResolvesResources
     public function resolve($request = null)
     {
         if ($this->resolvingRoot) {
-            /** @phpstan-ignore-next-line */
-            if (method_exists($this, 'beforeResolveRoot')) {
-                $this->beforeResolveRoot($request);
-            }
+            $this->beforeResolveRoot($request);
 
             return $this->resolveRoot($request, parent::resolve($request));
         }
 
         return parent::resolve($request);
+    }
+
+    protected function beforeResolveRoot(Request $request): void
+    {
     }
 
     protected function resolveRoot(Request $request, array $initiallyResolved): array

--- a/tests/Integration/BooksIndexResourceTest.php
+++ b/tests/Integration/BooksIndexResourceTest.php
@@ -66,7 +66,6 @@ class BooksIndexResourceTest extends ResourceTestCase
                 ->where('id', '!=', $book->author_id)
                 ->get();
 
-                
             $book->coauthors()->saveMany($otherAuthors);
         });
     }


### PR DESCRIPTION
Defines an empty implementation of beforeResolveRoot in trait to remove the need for a method_exists check, which is redundant within this package, but necessary outside of the context of this package. Now the method will always exist.